### PR TITLE
feat: input

### DIFF
--- a/src/app/v3/(routes)/(tabs)/main/page.tsx
+++ b/src/app/v3/(routes)/(tabs)/main/page.tsx
@@ -13,30 +13,66 @@ const Home = () => {
         example
       </Text>
       <Input type="text" placeholder="입력해주세요" variant="search" />
-      <Input type="text" placeholder="입력해주세요" variant="default" />
+      <Input placeholder="입력해주세요" variant="default" />
       <Input
-        type="text"
         placeholder="입력해주세요"
         variant="default"
-        right={<Icon name="close-circle" className="size-[24px]" fill="#B6C1C9" stroke="#4C5052" />}
+        right={
+          <Icon
+            name="close-circle"
+            className="mr-[6px] size-[24px]"
+            fill="#B6C1C9"
+            stroke="#4C5052"
+          />
+        }
       />
       <Input
-        type="text"
+        placeholder="입력해주세요"
+        variant="default"
+        message="메세지입니다"
+        label="라벨명"
+        right={
+          <Icon
+            name="close-circle"
+            className="mr-[6px] size-[24px]"
+            fill="#B6C1C9"
+            stroke="#4C5052"
+          />
+        }
+        TextComponent={Text}
+        IconComponent={Icon}
+      />
+      <Input
         placeholder="입력해주세요"
         variant="info"
         message="메세지입니다"
         label="라벨명"
-        right={<Icon name="close-circle" className="size-[24px]" fill="#B6C1C9" stroke="#4C5052" />}
+        essential={true}
+        right={
+          <Icon
+            name="close-circle"
+            className="mr-[6px] size-[24px]"
+            fill="#B6C1C9"
+            stroke="#4C5052"
+          />
+        }
       />
       <Input
-        type="text"
         placeholder="입력해주세요"
+        variant="default"
         message="메세지입니다"
         label="라벨명"
-        variant="default"
         hasError={true}
-        right={<Icon name="close-circle" className="size-[24px]" fill="#B6C1C9" stroke="#4C5052" />}
+        right={
+          <Icon
+            name="close-circle"
+            className="mr-[6px] size-[24px]"
+            fill="#B6C1C9"
+            stroke="#4C5052"
+          />
+        }
       />
+      <Input placeholder="입력해주세요" variant="note-title" />
     </div>
   )
 }

--- a/src/app/v3/(routes)/(tabs)/main/page.tsx
+++ b/src/app/v3/(routes)/(tabs)/main/page.tsx
@@ -12,11 +12,10 @@ const Home = () => {
       <Text as="a" typography="text1-bold" href="" className="">
         example
       </Text>
-      <Input type="text" placeholder="입력해주세요" variant="search" />
-      <Input placeholder="입력해주세요" variant="default" />
+      <Input type="text" placeholder="입력해주세요" variant="round" />
+      <Input placeholder="입력해주세요" />
       <Input
         placeholder="입력해주세요"
-        variant="default"
         right={
           <Icon
             name="cancel-circle"
@@ -28,7 +27,6 @@ const Home = () => {
       />
       <Input
         placeholder="입력해주세요"
-        variant="default"
         bottomText="메세지입니다"
         label="라벨명"
         right={
@@ -42,8 +40,7 @@ const Home = () => {
       />
       <Input
         placeholder="입력해주세요"
-        variant="info"
-        bottomText="메세지입니다"
+        bottomText={{ text: '메세지입니다', type: 'info' }}
         label="라벨명"
         essential={true}
         right={
@@ -57,7 +54,6 @@ const Home = () => {
       />
       <Input
         placeholder="입력해주세요"
-        variant="default"
         bottomText="메세지입니다"
         label="라벨명"
         hasError={true}
@@ -70,7 +66,7 @@ const Home = () => {
           />
         }
       />
-      <Input placeholder="입력해주세요" variant="note-title" />
+      <Input placeholder="입력해주세요" />
     </div>
   )
 }

--- a/src/app/v3/(routes)/(tabs)/main/page.tsx
+++ b/src/app/v3/(routes)/(tabs)/main/page.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@/shared/components/ui/button'
 import { Input } from '@/shared/components/ui/input'
+import { CloseCircle } from '@/shared/components/v3/icon/svg-components'
 
 const Home = () => {
   return (
@@ -29,6 +30,12 @@ const Home = () => {
       </Button>
       <Input type="text" placeholder="입력해주세요" variant="search" />
       <Input type="text" placeholder="입력해주세요" variant="default" />
+      <Input
+        type="text"
+        placeholder="입력해주세요"
+        variant="default"
+        right={<CloseCircle width="24" height="24" fill="#B6C1C9" stroke="#4C5052" />}
+      />
     </div>
   )
 }

--- a/src/app/v3/(routes)/(tabs)/main/page.tsx
+++ b/src/app/v3/(routes)/(tabs)/main/page.tsx
@@ -29,7 +29,7 @@ const Home = () => {
       <Input
         placeholder="입력해주세요"
         variant="default"
-        message="메세지입니다"
+        bottomText="메세지입니다"
         label="라벨명"
         right={
           <Icon
@@ -39,13 +39,11 @@ const Home = () => {
             stroke="#4C5052"
           />
         }
-        TextComponent={Text}
-        IconComponent={Icon}
       />
       <Input
         placeholder="입력해주세요"
         variant="info"
-        message="메세지입니다"
+        bottomText="메세지입니다"
         label="라벨명"
         essential={true}
         right={
@@ -60,7 +58,7 @@ const Home = () => {
       <Input
         placeholder="입력해주세요"
         variant="default"
-        message="메세지입니다"
+        bottomText="메세지입니다"
         label="라벨명"
         hasError={true}
         right={
@@ -73,7 +71,6 @@ const Home = () => {
         }
       />
       <Input placeholder="입력해주세요" variant="note-title" />
-      <Icon name="person" fill="#FB8320" />
     </div>
   )
 }

--- a/src/app/v3/(routes)/(tabs)/main/page.tsx
+++ b/src/app/v3/(routes)/(tabs)/main/page.tsx
@@ -19,7 +19,7 @@ const Home = () => {
         variant="default"
         right={
           <Icon
-            name="close-circle"
+            name="cancel-circle"
             className="mr-[6px] size-[24px]"
             fill="#B6C1C9"
             stroke="#4C5052"
@@ -33,7 +33,7 @@ const Home = () => {
         label="라벨명"
         right={
           <Icon
-            name="close-circle"
+            name="cancel-circle"
             className="mr-[6px] size-[24px]"
             fill="#B6C1C9"
             stroke="#4C5052"
@@ -50,7 +50,7 @@ const Home = () => {
         essential={true}
         right={
           <Icon
-            name="close-circle"
+            name="cancel-circle"
             className="mr-[6px] size-[24px]"
             fill="#B6C1C9"
             stroke="#4C5052"
@@ -65,7 +65,7 @@ const Home = () => {
         hasError={true}
         right={
           <Icon
-            name="close-circle"
+            name="cancel-circle"
             className="mr-[6px] size-[24px]"
             fill="#B6C1C9"
             stroke="#4C5052"
@@ -73,6 +73,7 @@ const Home = () => {
         }
       />
       <Input placeholder="입력해주세요" variant="note-title" />
+      <Icon name="person" fill="#FB8320" />
     </div>
   )
 }

--- a/src/app/v3/(routes)/(tabs)/main/page.tsx
+++ b/src/app/v3/(routes)/(tabs)/main/page.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/shared/components/ui/button'
+import { Input } from '@/shared/components/ui/input'
 
 const Home = () => {
   return (
@@ -26,6 +27,8 @@ const Home = () => {
       <Button variant="tinySquare" colors="unselected">
         버튼명
       </Button>
+      <Input type="text" placeholder="입력해주세요" variant="search" />
+      <Input type="text" placeholder="입력해주세요" variant="default" />
     </div>
   )
 }

--- a/src/shared/components/ui/input.tsx
+++ b/src/shared/components/ui/input.tsx
@@ -4,22 +4,24 @@ import { cn } from '@/shared/lib/utils'
 import { cva, VariantProps } from 'class-variance-authority'
 import Text from '../text'
 import Icon from '../v3/icon'
+import { Label } from './label'
 
 const inputVariants = cva(
   'flex h-[48px] w-full border bg-background-base-01 p-[12px] !text-subtitle2-medium text-text-primary ring-offset-transparent file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-subtitle2-medium placeholder:text-text-placeholder-01 focus-visible:outline-none disabled:cursor-not-allowed disabled:bg-background-disabled disabled:opacity-50 disabled:placeholder:text-text-disabled',
   {
     variants: {
       variant: {
-        none: '',
         default:
           'rounded-[8px] border-none bg-background-base-02 focus:bg-background-base-01 focus:ring-1 focus:ring-border-focused',
         info: 'rounded-[8px] border-none bg-background-base-02 focus:bg-background-base-01 focus:ring-1 focus:ring-border-focused',
         search:
           'rounded-[56px] border-none bg-background-base-03 px-[16px] py-[12px] placeholder:text-text-placeholder-01',
+        'note-title':
+          'h-fit border-none px-[16px] pb-[19px] pt-[24px] !text-title2 placeholder:text-text-placeholder-02',
       },
     },
     defaultVariants: {
-      variant: 'none',
+      variant: 'default',
     },
   }
 )
@@ -28,23 +30,49 @@ export interface InputProps
   extends React.InputHTMLAttributes<HTMLInputElement>,
     VariantProps<typeof inputVariants> {
   label?: string
+  essential?: boolean
   right?: React.ReactNode
   message?: string
   hasError?: boolean
+  LabelComponent?: React.ElementType
+  TextComponent?: React.ElementType
+  IconComponent?: React.ElementType
 }
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, variant, type, label, right, message, hasError = false, ...props }, ref) => {
+  (
+    {
+      className,
+      variant,
+      type = 'text',
+      label,
+      essential,
+      right,
+      message,
+      hasError = false,
+      LabelComponent = Label,
+      TextComponent = Text,
+      IconComponent = Icon,
+      ...props
+    },
+    ref
+  ) => {
+    const errorIcon =
+      hasError && IconComponent ? (
+        <IconComponent
+          name="close-circle"
+          className="size-[16px]"
+          fill="#F4502C"
+          stroke="#EBEFF3"
+        />
+      ) : null
+
     return (
       <div className={className}>
-        {label && (
-          <Text
-            as="label"
-            typography="text1-medium"
-            className={cn('mb-[8px] text-text-sub', hasError && 'text-text-critical')}
-          >
+        {label && LabelComponent && (
+          <LabelComponent essential={essential} hasError={hasError}>
             {label}
-          </Text>
+          </LabelComponent>
         )}
         <div className="relative w-full">
           <input
@@ -55,23 +83,26 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
               right && 'pr-[58px]'
             )}
             ref={ref}
+            aria-invalid={hasError}
             {...props}
           />
-          {right && <div className="absolute right-3 top-3 flex items-center">{right}</div>}
+          {right && (
+            <div className="absolute bottom-1/2 right-[12px] flex translate-y-1/2 items-center">
+              {right}
+            </div>
+          )}
         </div>
-        {message && (
-          <Text
+        {message && TextComponent && (
+          <TextComponent
             typography="text2-medium"
             className={cn('mt-[8px] flex items-center gap-[5px] text-text-caption', {
               'text-text-info': variant === 'info',
               'text-text-critical': hasError,
             })}
           >
-            {hasError && (
-              <Icon name="close-circle" className="size-[16px]" fill="#F4502C" stroke="#EBEFF3" />
-            )}
+            {errorIcon}
             {message}
-          </Text>
+          </TextComponent>
         )}
       </div>
     )

--- a/src/shared/components/ui/input.tsx
+++ b/src/shared/components/ui/input.tsx
@@ -11,6 +11,8 @@ const inputVariants = cva(
         none: '',
         default:
           'rounded-[8px] border-none bg-background-base-02 focus:bg-background-base-01 focus:ring-1 focus:ring-border-focused',
+        info: '',
+        disabled: '',
         search:
           'rounded-[56px] border-none bg-background-base-03 px-[16px] py-[12px] placeholder:text-text-placeholder-01',
       },
@@ -23,17 +25,22 @@ const inputVariants = cva(
 
 export interface InputProps
   extends React.InputHTMLAttributes<HTMLInputElement>,
-    VariantProps<typeof inputVariants> {}
+    VariantProps<typeof inputVariants> {
+  right?: React.ReactNode
+}
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, variant, type, ...props }, ref) => {
+  ({ className, variant, type, right, ...props }, ref) => {
     return (
-      <input
-        type={type}
-        className={cn(inputVariants({ variant }), className)}
-        ref={ref}
-        {...props}
-      />
+      <div className="relative w-full">
+        <input
+          type={type}
+          className={cn(inputVariants({ variant }), className)}
+          ref={ref}
+          {...props}
+        />
+        {right && <div className="absolute right-3 top-3 flex items-center">{right}</div>}
+      </div>
     )
   }
 )

--- a/src/shared/components/ui/input.tsx
+++ b/src/shared/components/ui/input.tsx
@@ -13,11 +13,8 @@ const inputVariants = cva(
       variant: {
         default:
           'rounded-[8px] border-none bg-background-base-02 focus:bg-background-base-01 focus:ring-1 focus:ring-border-focused',
-        info: 'rounded-[8px] border-none bg-background-base-02 focus:bg-background-base-01 focus:ring-1 focus:ring-border-focused',
-        search:
+        round:
           'rounded-[56px] border-none bg-background-base-03 px-[16px] py-[12px] placeholder:text-text-placeholder-01',
-        'note-title':
-          'h-fit border-none px-[16px] pb-[19px] pt-[24px] !text-title2 placeholder:text-text-placeholder-02',
       },
     },
     defaultVariants: {
@@ -32,7 +29,7 @@ export interface InputProps
   label?: string
   essential?: boolean
   right?: React.ReactNode
-  bottomText?: string
+  bottomText?: string | { text: string; type: 'info' }
   hasError?: boolean
 }
 
@@ -58,6 +55,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
             {label}
           </Label>
         )}
+
         <div className="relative w-full">
           <input
             type={type}
@@ -76,18 +74,19 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
             </div>
           )}
         </div>
+
         {bottomText && (
           <Text
             typography="text2-medium"
             className={cn('mt-[8px] flex items-center gap-[5px] text-text-caption', {
-              'text-text-info': variant === 'info',
+              'text-text-info': bottomText instanceof Object && bottomText.type === 'info',
               'text-text-critical': hasError,
             })}
           >
             {hasError ? (
               <Icon name="cancel-circle" className="size-[16px]" fill="#F4502C" stroke="#EBEFF3" />
             ) : null}
-            {bottomText}
+            {bottomText instanceof Object ? bottomText.text : bottomText}
           </Text>
         )}
       </div>

--- a/src/shared/components/ui/input.tsx
+++ b/src/shared/components/ui/input.tsx
@@ -4,7 +4,7 @@ import { cn } from '@/shared/lib/utils'
 import { cva, VariantProps } from 'class-variance-authority'
 import Text from '../text'
 import Icon from '../v3/icon'
-import { Label } from './label'
+import Label from './label'
 
 const inputVariants = cva(
   'flex h-[48px] w-full border bg-background-base-01 p-[12px] !text-subtitle2-medium text-text-primary ring-offset-transparent file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-subtitle2-medium placeholder:text-text-placeholder-01 focus-visible:outline-none disabled:cursor-not-allowed disabled:bg-background-disabled disabled:opacity-50 disabled:placeholder:text-text-disabled',
@@ -32,11 +32,8 @@ export interface InputProps
   label?: string
   essential?: boolean
   right?: React.ReactNode
-  message?: string
+  bottomText?: string
   hasError?: boolean
-  LabelComponent?: React.ElementType
-  TextComponent?: React.ElementType
-  IconComponent?: React.ElementType
 }
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
@@ -48,31 +45,18 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       label,
       essential,
       right,
-      message,
+      bottomText,
       hasError = false,
-      LabelComponent = Label,
-      TextComponent = Text,
-      IconComponent = Icon,
       ...props
     },
     ref
   ) => {
-    const errorIcon =
-      hasError && IconComponent ? (
-        <IconComponent
-          name="close-circle"
-          className="size-[16px]"
-          fill="#F4502C"
-          stroke="#EBEFF3"
-        />
-      ) : null
-
     return (
       <div className={className}>
-        {label && LabelComponent && (
-          <LabelComponent essential={essential} hasError={hasError}>
+        {label && (
+          <Label essential={essential} hasError={hasError}>
             {label}
-          </LabelComponent>
+          </Label>
         )}
         <div className="relative w-full">
           <input
@@ -92,17 +76,19 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
             </div>
           )}
         </div>
-        {message && TextComponent && (
-          <TextComponent
+        {bottomText && (
+          <Text
             typography="text2-medium"
             className={cn('mt-[8px] flex items-center gap-[5px] text-text-caption', {
               'text-text-info': variant === 'info',
               'text-text-critical': hasError,
             })}
           >
-            {errorIcon}
-            {message}
-          </TextComponent>
+            {hasError ? (
+              <Icon name="cancel-circle" className="size-[16px]" fill="#F4502C" stroke="#EBEFF3" />
+            ) : null}
+            {bottomText}
+          </Text>
         )}
       </div>
     )

--- a/src/shared/components/ui/input.tsx
+++ b/src/shared/components/ui/input.tsx
@@ -1,18 +1,36 @@
 import * as React from 'react'
 
 import { cn } from '@/shared/lib/utils'
+import { cva, VariantProps } from 'class-variance-authority'
 
-export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+const inputVariants = cva(
+  'flex h-[48px] w-full border bg-background-base-01 p-[12px] !text-subtitle2-medium text-text-primary ring-offset-transparent file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-subtitle2-medium placeholder:text-text-placeholder-01 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50',
+  {
+    variants: {
+      variant: {
+        none: '',
+        default:
+          'rounded-[8px] border-none bg-background-base-02 focus:bg-background-base-01 focus:ring-1 focus:ring-border-focused',
+        search:
+          'rounded-[56px] border-none bg-background-base-03 px-[16px] py-[12px] placeholder:text-text-placeholder-01',
+      },
+    },
+    defaultVariants: {
+      variant: 'none',
+    },
+  }
+)
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement>,
+    VariantProps<typeof inputVariants> {}
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, ...props }, ref) => {
+  ({ className, variant, type, ...props }, ref) => {
     return (
       <input
         type={type}
-        className={cn(
-          'flex h-[40px] w-full !text-body1-medium border text-gray-09 border-input bg-background px-3 py-[10px] ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 placeholder:text-gray-06 placeholder:text-body2-regular-eng',
-          className
-        )}
+        className={cn(inputVariants({ variant }), className)}
         ref={ref}
         {...props}
       />

--- a/src/shared/components/ui/label.tsx
+++ b/src/shared/components/ui/label.tsx
@@ -20,7 +20,7 @@ interface LabelProps
 
 const Label = React.forwardRef<React.ElementRef<typeof LabelPrimitive.Root>, LabelProps>(
   ({ className, essential = false, hasError = false, ...props }, ref) => {
-    const essentialIcon = essential ? <Icon name="essential" /> : null
+    const essentialIcon = essential ? <Icon name="asterisk" /> : null
 
     return (
       <LabelPrimitive.Root

--- a/src/shared/components/ui/label.tsx
+++ b/src/shared/components/ui/label.tsx
@@ -5,17 +5,35 @@ import * as LabelPrimitive from '@radix-ui/react-label'
 import { cva, type VariantProps } from 'class-variance-authority'
 
 import { cn } from '@/shared/lib/utils'
+import Icon from '../v3/icon'
 
 const labelVariants = cva(
-  'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70'
+  'mb-[8px] !flex items-center !text-text1-medium leading-none text-text-sub peer-disabled:cursor-not-allowed peer-disabled:opacity-70'
 )
 
-const Label = React.forwardRef<
-  React.ElementRef<typeof LabelPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> & VariantProps<typeof labelVariants>
->(({ className, ...props }, ref) => (
-  <LabelPrimitive.Root ref={ref} className={cn(labelVariants(), className)} {...props} />
-))
+interface LabelProps
+  extends React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>,
+    VariantProps<typeof labelVariants> {
+  essential?: boolean
+  hasError?: boolean
+}
+
+const Label = React.forwardRef<React.ElementRef<typeof LabelPrimitive.Root>, LabelProps>(
+  ({ className, essential = false, hasError = false, ...props }, ref) => {
+    const essentialIcon = essential ? <Icon name="essential" /> : null
+
+    return (
+      <LabelPrimitive.Root
+        ref={ref}
+        className={cn(labelVariants(), className, hasError && 'text-text-critical')}
+        {...props}
+      >
+        <span>{props.children}</span>
+        {essentialIcon}
+      </LabelPrimitive.Root>
+    )
+  }
+)
 Label.displayName = LabelPrimitive.Root.displayName
 
 export { Label }

--- a/src/shared/components/ui/label.tsx
+++ b/src/shared/components/ui/label.tsx
@@ -36,4 +36,4 @@ const Label = React.forwardRef<React.ElementRef<typeof LabelPrimitive.Root>, Lab
 )
 Label.displayName = LabelPrimitive.Root.displayName
 
-export { Label }
+export default Label

--- a/src/shared/components/ui/tag.tsx
+++ b/src/shared/components/ui/tag.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { cn } from '@/shared/lib/utils'
+
+const tagVariants = cva(
+  'inline-flex h-[19px] w-[38px] items-center justify-center whitespace-nowrap rounded-[4px] px-[6px] py-[2px] !text-caption-medium transition-colors',
+  {
+    variants: {
+      colors: {
+        special: 'bg-gradient-to-r from-orange-500 to-blue-400 text-button-label-primary',
+        primary:
+          'bg-button-fill-primary text-button-label-primary hover:bg-button-fill-primary-hover',
+        'primary-loading': 'bg-button-fill-primary-loading text-button-label-primary',
+        secondary: 'bg-button-fill-secondary text-button-label-secondary',
+        tertiary: 'bg-button-fill-tertiary text-button-label-tertiary',
+        outlined: 'border border-border-default bg-button-fill-outlined text-button-label-tertiary',
+      },
+    },
+    defaultVariants: {
+      colors: 'primary',
+    },
+  }
+)
+
+interface TagProps
+  extends React.HTMLAttributes<HTMLSpanElement>,
+    VariantProps<typeof tagVariants> {}
+
+const Tag = React.forwardRef<HTMLSpanElement, TagProps>(
+  ({ className, colors, children, ...props }) => {
+    return (
+      <span className={cn(tagVariants({ colors }), className)} {...props}>
+        {children}
+      </span>
+    )
+  }
+)
+Tag.displayName = 'Tag'
+
+export default Tag

--- a/src/shared/components/v3/icon/svg-components.tsx
+++ b/src/shared/components/v3/icon/svg-components.tsx
@@ -1163,3 +1163,22 @@ export const Download = ({ ...props }) => {
     </svg>
   )
 }
+
+// (*)
+export const Essential = ({ ...props }) => {
+  return (
+    <svg
+      width="7"
+      height="15"
+      viewBox="0 0 7 15"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path
+        d="M3.928 1V2.776L5.584 2.248L5.884 3.172L4.228 3.7L5.296 5.164L4.528 5.764L3.436 4.276L2.356 5.764L1.6 5.152L2.668 3.7L1 3.172L1.3 2.248L2.956 2.776L2.944 1H3.928Z"
+        fill="#FB8320"
+      />
+    </svg>
+  )
+}

--- a/src/shared/components/v3/icon/svg-components.tsx
+++ b/src/shared/components/v3/icon/svg-components.tsx
@@ -1147,7 +1147,7 @@ export const Download = ({ ...props }) => {
 }
 
 // (*)
-export const Essential = ({ ...props }) => {
+export const Asterisk = ({ ...props }) => {
   return (
     <svg
       width="7"

--- a/src/shared/components/v3/icon/svg-components.tsx
+++ b/src/shared/components/v3/icon/svg-components.tsx
@@ -6,7 +6,7 @@ function generateUUID() {
   })
 }
 
-export const Add = ({ ...props }) => {
+export const Plus = ({ ...props }) => {
   return (
     <svg
       width="20"
@@ -22,7 +22,7 @@ export const Add = ({ ...props }) => {
   )
 }
 
-export const AddCircle = ({ ...props }) => {
+export const PlusCircle = ({ ...props }) => {
   const { fill, stroke, ...rest } = props
 
   return (
@@ -96,7 +96,7 @@ export const Search = ({ ...props }) => {
   )
 }
 
-export const LeftArrow = ({ ...props }) => {
+export const ArrowLeft = ({ ...props }) => {
   return (
     <svg
       width="20"
@@ -123,7 +123,7 @@ export const LeftArrow = ({ ...props }) => {
   )
 }
 
-export const RightArrow = ({ ...props }) => {
+export const ArrowRight = ({ ...props }) => {
   return (
     <svg
       width="20"
@@ -150,7 +150,7 @@ export const RightArrow = ({ ...props }) => {
   )
 }
 
-export const Close = ({ ...props }) => {
+export const Cancel = ({ ...props }) => {
   return (
     <svg
       width="20"
@@ -178,7 +178,7 @@ export const Close = ({ ...props }) => {
   )
 }
 
-export const CloseCircle = ({ ...props }) => {
+export const CancelCircle = ({ ...props }) => {
   const { fill, stroke, ...rest } = props
 
   return (
@@ -587,24 +587,6 @@ export const Folder = ({ ...props }) => {
   )
 }
 
-export const Picktoss = ({ ...props }) => {
-  return (
-    <svg
-      width="20"
-      height="20"
-      viewBox="0 0 20 20"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      {...props}
-    >
-      <path
-        d="M17.1104 0.883103C17.1104 0.883103 17.0876 0.886781 17.0773 0.891212C12.3453 2.09202 7.30589 3.76434 3.57904 7.0713C1.99569 8.47894 0.736296 10.3127 0.605521 12.4895C0.400969 15.8944 2.98387 18.8202 6.37408 19.0239C7.76975 19.1077 9.16955 18.7044 10.3099 17.8889C11.4058 17.1036 12.1524 15.9362 12.7606 14.7275C13.7005 12.8544 16.3134 7.7454 16.3134 7.7454C16.4044 7.57154 16.2326 7.37433 16.0497 7.44669C15.1837 7.62955 13.2418 8.22512 12.4989 8.66037C12.3973 8.71993 12.2749 8.62165 12.3093 8.51006C12.6391 7.41606 13.3921 6.35002 13.9855 5.43097C14.9756 3.89424 16.0909 2.49131 17.3495 1.17276C17.3897 1.13224 17.4303 1.08417 17.4338 1.02628C17.4421 0.887874 17.2526 0.861334 17.1103 0.88562L17.1104 0.883103Z"
-        fill="white"
-      />
-    </svg>
-  )
-}
-
 export const Setting = ({ ...props }) => {
   const clipId = generateUUID()
 
@@ -848,7 +830,7 @@ export const Notion = ({ ...props }) => {
   )
 }
 
-export const DownChevron = ({ ...props }) => {
+export const ChevronDown = ({ ...props }) => {
   return (
     <svg
       width="16"
@@ -869,7 +851,7 @@ export const DownChevron = ({ ...props }) => {
   )
 }
 
-export const UpChevron = ({ ...props }) => {
+export const ChevronUp = ({ ...props }) => {
   return (
     <svg
       width="16"
@@ -890,7 +872,7 @@ export const UpChevron = ({ ...props }) => {
   )
 }
 
-export const LeftChevron = ({ ...props }) => {
+export const ChevronLeft = ({ ...props }) => {
   return (
     <svg
       width="16"
@@ -911,7 +893,7 @@ export const LeftChevron = ({ ...props }) => {
   )
 }
 
-export const RightChevron = ({ ...props }) => {
+export const ChevronRight = ({ ...props }) => {
   return (
     <svg
       width="16"
@@ -932,7 +914,7 @@ export const RightChevron = ({ ...props }) => {
   )
 }
 
-export const LeftTriangle = ({ ...props }) => {
+export const TriangleLeft = ({ ...props }) => {
   return (
     <svg
       width="16"
@@ -947,7 +929,7 @@ export const LeftTriangle = ({ ...props }) => {
   )
 }
 
-export const RightTriangle = ({ ...props }) => {
+export const TriangleRight = ({ ...props }) => {
   return (
     <svg
       width="16"
@@ -1178,6 +1160,101 @@ export const Essential = ({ ...props }) => {
       <path
         d="M3.928 1V2.776L5.584 2.248L5.884 3.172L4.228 3.7L5.296 5.164L4.528 5.764L3.436 4.276L2.356 5.764L1.6 5.152L2.668 3.7L1 3.172L1.3 2.248L2.956 2.776L2.944 1H3.928Z"
         fill="#FB8320"
+      />
+    </svg>
+  )
+}
+
+// GNB
+export const Person = ({ ...props }) => {
+  const { fill, ...rest } = props
+
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...rest}
+    >
+      <circle cx="12" cy="6" r="5" fill={(fill as string) ?? '#D3DCE4'} />
+      <path
+        d="M22 20.3269C22 24.3734 17.5228 23.9903 12 23.9903C6.47715 23.9903 2 24.3734 2 20.3269C2 16.2803 6.47715 13 12 13C17.5228 13 22 16.2803 22 20.3269Z"
+        fill={(fill as string) ?? '#D3DCE4'}
+      />
+    </svg>
+  )
+}
+
+export const Planet = ({ ...props }) => {
+  const { fill, ...rest } = props
+  const clipId = generateUUID()
+
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...rest}
+    >
+      <g clip-path={`url(#${clipId})`}>
+        <path
+          fill-rule="evenodd"
+          clip-rule="evenodd"
+          d="M0.715456 23.1813C2.26657 24.7324 6.01863 23.6774 10.2426 20.8285C10.811 20.941 11.3986 21 12 21C16.9706 21 21 16.9706 21 12C21 11.412 20.9436 10.8371 20.8359 10.2806C23.7569 5.99919 24.8529 2.18057 23.2845 0.612185C21.7043 -0.9681 17.8395 0.156629 13.5186 3.12759C13.025 3.04369 12.5176 3 12 3C7.02944 3 3 7.02944 3 12C3 12.5309 3.04598 13.0511 3.13416 13.5568C0.235651 17.8204 -0.847566 21.6182 0.715456 23.1813ZM2.53126 19.7402C3.08904 20.298 4.45617 19.9469 6.24551 18.9203C6.23825 18.9142 6.231 18.9082 6.22376 18.9021C7.08452 18.4667 7.9482 17.7608 8.98693 16.681C9.15617 16.5051 8.86763 16.1874 8.65899 16.3142C7.14643 17.2329 5.94069 17.5613 5.05767 17.7279C4.5864 17.1573 4.18411 16.5277 3.86357 15.8518C2.51134 17.7242 1.92687 19.1358 2.53126 19.7402ZM19.8218 2.44962C20.3906 3.01837 20.0144 4.42862 18.9405 6.26995C18.1021 5.25558 17.0456 4.42809 15.8428 3.85932C17.7601 2.4614 19.2123 1.84008 19.8218 2.44962Z"
+          fill={(fill as string) ?? '#D3DCE4'}
+        />
+      </g>
+      <defs>
+        <clipPath id={clipId}>
+          <rect width="24" height="24" fill="white" />
+        </clipPath>
+      </defs>
+    </svg>
+  )
+}
+
+export const QuizNote = ({ ...props }) => {
+  const { fill, ...rest } = props
+
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...rest}
+    >
+      <path
+        d="M1 4.32722C1 3.57554 1.57318 2.94789 2.32177 2.87984C5.04576 2.6322 7.78193 3.19924 10.1832 4.50901L12 5.5L13.8168 4.50901C16.2181 3.19924 18.9542 2.6322 21.6782 2.87984C22.4268 2.94789 23 3.57554 23 4.32722V18.5293C23 19.2951 22.3065 19.8739 21.553 19.7369C18.9304 19.2601 16.2236 19.6962 13.8835 20.9726L12.7689 21.5806C12.2896 21.842 11.7104 21.842 11.2311 21.5806L10.1165 20.9726C7.77636 19.6962 5.06956 19.2601 2.44698 19.7369C1.69354 19.8739 1 19.2951 1 18.5293V4.32722Z"
+        fill={(fill as string) ?? '#D3DCE4'}
+      />
+      <circle cx="6.95" cy="12.25" r="1.25" fill="white" />
+      <circle cx="11.95" cy="12.25" r="1.25" fill="white" />
+      <circle cx="16.95" cy="12.25" r="1.25" fill="white" />
+    </svg>
+  )
+}
+
+export const Picktoss = ({ ...props }) => {
+  const { fill, ...rest } = props
+
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...rest}
+    >
+      <path
+        d="M17.1104 0.883103C17.1104 0.883103 17.0876 0.886781 17.0773 0.891212C12.3453 2.09202 7.30589 3.76434 3.57904 7.0713C1.99569 8.47894 0.736296 10.3127 0.605521 12.4895C0.400969 15.8944 2.98387 18.8202 6.37408 19.0239C7.76975 19.1077 9.16955 18.7044 10.3099 17.8889C11.4058 17.1036 12.1524 15.9362 12.7606 14.7275C13.7005 12.8544 16.3134 7.7454 16.3134 7.7454C16.4044 7.57154 16.2326 7.37433 16.0497 7.44669C15.1837 7.62955 13.2418 8.22512 12.4989 8.66037C12.3973 8.71993 12.2749 8.62165 12.3093 8.51006C12.6391 7.41606 13.3921 6.35002 13.9855 5.43097C14.9756 3.89424 16.0909 2.49131 17.3495 1.17276C17.3897 1.13224 17.4303 1.08417 17.4338 1.02628C17.4421 0.887874 17.2526 0.861334 17.1103 0.88562L17.1104 0.883103Z"
+        fill={(fill as string) ?? '#D3DCE4'}
       />
     </svg>
   )


### PR DESCRIPTION
## 개요
![스크린샷 2024-09-27 104130](https://github.com/user-attachments/assets/02039a4d-4134-4fb2-af45-ac280efb3bcb)


### 세부 내용
이런식으로 구현 마무리 해봤습니다!

- Input 컴포넌트 구현
  - Input 내에서 label, message 처리
  - variant : default / info / search / note-title ==( 변경 )==> default / round

- label 컴포넌트 구현
  - Input에 맞춰 기존 컴포넌트를 수정

- Icon 컴포넌트 수정 (Live Share)
- svg-components에 asterisk(*) 추가
- svg-components에 person / planet / quiz-note 추가 (GNB 하단 네비게이션 아이콘들)
- 몇 가지 아이콘 이름 수정 (add => plus / close => cancel 등)


### 관련 링크
